### PR TITLE
Allow custom .env location

### DIFF
--- a/packages/backend/src/config/environment.ts
+++ b/packages/backend/src/config/environment.ts
@@ -3,7 +3,11 @@ import dotenv from 'dotenv';
 import path from 'node:path';
 
 // Load environment variables from .env file
-dotenv.config({ path: path.resolve(process.cwd(), '../../.env') });
+// Allow overriding the path via the ENV_PATH environment variable
+const envPath = process.env.ENV_PATH
+  ? path.resolve(process.cwd(), process.env.ENV_PATH)
+  : path.resolve(__dirname, '../../../../.env');
+dotenv.config({ path: envPath });
 
 // Define schema for environment variables with validation
 const envSchema = z.object({


### PR DESCRIPTION
## Summary
- make backend environment loader use repo root `.env` by default
- support overriding via `ENV_PATH`

## Testing
- `npm test --prefix packages/backend` *(fails: jest not found)*
- `npm start --prefix packages/backend` *(fails: module-alias/register missing)*