### PR TITLE
Remove next() in backend error middleware

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -48,7 +48,6 @@ app.use((err: Error, req: express.Request, res: express.Response, next: express.
     message: 'An unexpected error occurred',
     error: env.NODE_ENV === 'development' ? err.message : undefined,
   });
-  next();
 });
 
 // Start server


### PR DESCRIPTION
## Summary
- clean up error handling middleware

## Testing
- `npm test` *(fails: turbo not found)*