### PR TITLE
Fix test setup path

### DIFF
--- a/packages/frontend/src/test/setup.ts
+++ b/packages/frontend/src/test/setup.ts
@@ -1,0 +1,3 @@
+import '@testing-library/jest-dom';
+
+// Add any additional global test setup here if needed


### PR DESCRIPTION
## Summary
- add missing Vitest setup file so `vite.config.ts` path resolves

## Testing
- `npm run test` *(fails: turbo not found)*